### PR TITLE
fix(ci): avoid false failures in check-emergency workflow

### DIFF
--- a/.github/workflows/check-emergency.yml
+++ b/.github/workflows/check-emergency.yml
@@ -30,9 +30,12 @@ jobs:
         id: check
         run: |
           cd scripts
+          set +e
           python scrape_official.py --check-emergency --output-json
-          echo "exit_code=$?" >> $GITHUB_OUTPUT
-        continue-on-error: true
+          EXIT_CODE=$?
+          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+          # Exit code 1 = hay renovaciones por verificar, no es error de workflow.
+          exit 0
 
       - name: Leer resultado
         id: result


### PR DESCRIPTION
### Motivation
- Evitar que el paso de GitHub Actions `check-emergency` marque la ejecución como fallida cuando el scraper devuelve `1` (significa que hay decretos que requieren revisión y no es un error técnico). 

### Description
- Actualicé ` .github/workflows/check-emergency.yml` para ejecutar `python scrape_official.py --check-emergency --output-json` con `set +e`, capturar `EXIT_CODE`, escribir `exit_code` en `$GITHUB_OUTPUT` y finalizar el step con `exit 0` para que el workflow no falle ante el código de salida esperado. 

### Testing
- Ejecuté `python scripts/scrape_official.py --help` correctamente y revisé el diff del workflow para confirmar que `exit_code` se emite hacia `$GITHUB_OUTPUT`, y la validación YAML no pudo correrse en este entorno porque `PyYAML` no está instalado (por lo que no se pudo ejecutar `yaml.safe_load`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964cd7a9d4832b9914d265994cc33a)