### PR TITLE
fix(ci): interpret scraper exit codes and harden issue creation

### DIFF
--- a/.github/workflows/check-emergency.yml
+++ b/.github/workflows/check-emergency.yml
@@ -30,9 +30,19 @@ jobs:
         id: check
         run: |
           cd scripts
+          set +e
           python scrape_official.py --check-emergency --output-json
-          echo "exit_code=$?" >> $GITHUB_OUTPUT
-        continue-on-error: true
+          EXIT_CODE=$?
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+          # Semantica del script:
+          # 0 = sin cambios, 1 = cambios detectados (esperado), 2 = error tecnico.
+          if [ "$EXIT_CODE" -eq 2 ]; then
+            echo "::error::El verificador de emergencia fallo con codigo 2."
+            exit 2
+          fi
+
+          exit 0
 
       - name: Leer resultado
         id: result
@@ -80,14 +90,19 @@ jobs:
       - name: Crear Issue si hay cambios
         if: steps.result.outputs.needs_update != '0'
         run: |
-          # De-duplicacion: no crear issue si ya existe uno abierto con el mismo label
-          EXISTING=$(gh issue list --label "legal-data,urgent,country:PE" --state open --limit 1 --json number -q '.[0].number' || echo "")
+          # De-duplicacion: no crear issue si ya existe uno abierto
+          EXISTING=$(gh issue list --label "legal-data" --state open --limit 1 --json number -q '.[0].number' || echo "")
           if [ -z "$EXISTING" ]; then
             BODY=$(cat issue_body.txt 2>/dev/null || echo "Verificacion automatica detecto cambios en estado de emergencia.")
             gh issue create \
               --title "Estado de emergencia: verificar renovacion de decreto" \
               --body "$BODY" \
-              --label "legal-data,urgent,country:PE"
+              --label "legal-data" \
+              --label "urgent" \
+              --label "country:PE" || \
+            gh issue create \
+              --title "Estado de emergencia: verificar renovacion de decreto" \
+              --body "$BODY"
           else
             echo "Issue #$EXISTING ya existe, no se crea duplicado."
           fi

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -30,9 +30,19 @@ jobs:
         id: check
         run: |
           cd scripts
+          set +e
           python scrape_official.py --check-updates --output-json
-          echo "exit_code=$?" >> $GITHUB_OUTPUT
-        continue-on-error: true
+          EXIT_CODE=$?
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+          # Semantica del script:
+          # 0 = sin cambios, 1 = cambios detectados (esperado), 2 = error tecnico.
+          if [ "$EXIT_CODE" -eq 2 ]; then
+            echo "::error::El verificador de fuentes fallo con codigo 2."
+            exit 2
+          fi
+
+          exit 0
 
       - name: Leer resultado
         id: result
@@ -77,13 +87,17 @@ jobs:
       - name: Crear Issue si hay fuentes desactualizadas
         if: steps.result.outputs.needs_update != '0'
         run: |
-          EXISTING=$(gh issue list --label "legal-data,legal-review" --state open --limit 1 --json number -q '.[0].number' || echo "")
+          EXISTING=$(gh issue list --label "legal-data" --state open --limit 1 --json number -q '.[0].number' || echo "")
           if [ -z "$EXISTING" ]; then
             BODY=$(cat issue_body.txt 2>/dev/null || echo "Verificacion automatica detecto fuentes desactualizadas.")
             gh issue create \
               --title "Fuentes legales: revision de vigencia necesaria" \
               --body "$BODY" \
-              --label "legal-data,legal-review"
+              --label "legal-data" \
+              --label "legal-review" || \
+            gh issue create \
+              --title "Fuentes legales: revision de vigencia necesaria" \
+              --body "$BODY"
           else
             echo "Issue #$EXISTING ya existe, no se crea duplicado."
           fi


### PR DESCRIPTION
### Motivation
- Evitar que los workflows programados se marquen como fallidos cuando el scraper devuelve `1` (cambios detectados) pero seguir fallando en errores técnicos reales (`2`).
- Hacer la creación de issues más robusta para que fallos en etiquetado o en `gh issue create` no rompan el job.

### Description
- En `check-emergency.yml` y `check-updates.yml` se añadió `set +e`, se captura `EXIT_CODE` tras ejecutar el scraper y se exporta con `echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"`.
- Los jobs ahora solo fallan explícitamente si `EXIT_CODE` es `2` (error técnico), mientras que `0` (sin cambios) y `1` (cambios detectados) terminan con `exit 0` para no marcar el workflow como fallo.
- Se endureció la lógica de creación de issues: la desduplicación usa la etiqueta base `legal-data`, las etiquetas se pasan con `--label` repetido y se añade un intento de fallback para crear el issue sin etiquetas si la llamada con etiquetas falla.
- Se reemplazó el uso implícito de `continue-on-error` por manejo explícito del código de salida y se aseguró el correcto escapado/quoting de `$GITHUB_OUTPUT`.

### Testing
- Ejecuté `python scripts/scrape_official.py --help` y devolvió la ayuda del script correctamente. (éxito)
- Inspeccioné los diffs de los workflows para verificar que `exit_code` se exporta, que existe la ruta de fallo para `EXIT_CODE=2` y que la creación de issues incluye el fallback (revisión de cambios, éxito).
- No se ejecutó CI en GitHub desde este entorno, por lo que la validación en el runner real queda pendiente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964cd7a9d4832b9914d265994cc33a)